### PR TITLE
Make it easier to tell when a device reboots

### DIFF
--- a/apps/testbench/src/testbench.c
+++ b/apps/testbench/src/testbench.c
@@ -383,6 +383,8 @@ main(int argc, char **argv)
 
     testbench_test_init(); /* initialize globals include blink duty cycle */
 
+    LOG_INFO(&testlog, LOG_MODULE_TEST, "testbench app initialized");
+
     while (1) {
         os_eventq_run(os_eventq_dflt_get());
     }


### PR DESCRIPTION
Logging a message on startup will make it easier to tell if a device
rebooted.